### PR TITLE
Added the time tracking component that you wanted.

### DIFF
--- a/Aetherium/Items/Voidheart.cs
+++ b/Aetherium/Items/Voidheart.cs
@@ -254,7 +254,7 @@ namespace Aetherium.Items
             {
                 if (self.combinedHealth <= self.fullCombinedHealth * Mathf.Clamp((0.3f + (0.05f * InventoryCount - 1)), 0.3f, 0.99f) &&
                     //This check is for the timer to determine time since spawn, at <= 10f it'll only activate after the tenth second
-                    self.GetComponent<VoidHeartPrevention>().internalTimer <= 10f)
+                    self.GetComponent<VoidHeartPrevention>().internalTimer >= 10f)
                 {
                     RoR2.DamageInfo damageInfo = new RoR2.DamageInfo();
                     damageInfo.crit = false;


### PR DESCRIPTION
Its fairly simple to operate and is attached to all CharacterBody on Start. All it does is update the time on Update and it has a reset function if that ever turns out to be useful. Fun side-effect of hooking on Start is that it resets the timer every time the effect triggers, so that can be used as a second emergency check if need be. Commits have a bit more detail if you need it.