### PR TITLE
Turret Drone Positioning

### DIFF
--- a/Aetherium/Aetherium.csproj
+++ b/Aetherium/Aetherium.csproj
@@ -77,4 +77,8 @@
     <Folder Include="Equipment\" />
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;C:\Program Files (x86)\Steam\steamapps\common\Risk of Rain 2\r2modman\BepInEx\plugins\KomradeSpectre-Aetherium&quot; /Y" />
+  </Target>
+
 </Project>

--- a/Aetherium/Items/InspiringDrone.cs
+++ b/Aetherium/Items/InspiringDrone.cs
@@ -317,7 +317,7 @@ namespace Aetherium.Items
                     botToBeUpgradedMaster.GetBody().statsDirty = true;
 
                     //Add stock to bots that can use it.
-                    String[] BlacklistedBots = {"Drone2Master", "EmergencyDroneMaster", "FlameDroneMaster", "EquipmentDroneMaster"};
+                    string[] BlacklistedBots = {"Drone2Master", "EmergencyDroneMaster", "FlameDroneMaster", "EquipmentDroneMaster"};
                     var BotIsBlacklisted = Array.Exists(BlacklistedBots, element => botToBeUpgradedMaster.gameObject.name.StartsWith(element));
                     if (!BotIsBlacklisted) 
                     {
@@ -407,6 +407,7 @@ namespace Aetherium.Items
                                 if(Vector3.Distance(self.corePosition, TargetBody.corePosition) >= turretTeleportationDistanceAroundOwner) 
                                 {
                                     TeleportBody(self, TargetBody.corePosition, MapNodeGroup.GraphType.Ground);
+                                    self.transform.position += self.transform.up * .9f;
                                     TrackerComponent.TeleportTimer = turretTeleportationCooldownDuration;
                                 }
                             }


### PR DESCRIPTION
Allow Turret Drones to teleport properly and place them above ground using their `transform.up` axis.

Also add a post build event that copies the DLL into BePiNex folder. This is configured in an R2modman setup, so change the paths as you see fit.