### PR TITLE
Inspiring Drone Improvements, Fixes & New Features

### DIFF
--- a/Aetherium/Aetherium.cs
+++ b/Aetherium/Aetherium.cs
@@ -1,4 +1,6 @@
-﻿using BepInEx;
+﻿#undef DEBUG
+
+using BepInEx;
 using BepInEx.Configuration;
 using R2API;
 using R2API.Utils;
@@ -32,6 +34,11 @@ namespace KomradeSpectre.Aetherium
         private void Awake() //Sourced almost entirely from ThinkInvis' Classic Items. It is also extremely handy.
         {
             _logger = Logger;
+
+#if DEBUG
+            Logger.LogWarning("DEBUG mode is enabled! Ignore this message if you are actually debugging.");
+            On.RoR2.Networking.GameNetworkManager.OnClientConnect += (self, user, t) => { };
+#endif
 
             using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("Aetherium.aetherium_assets"))
             {

--- a/Aetherium/Items/InspiringDrone.cs
+++ b/Aetherium/Items/InspiringDrone.cs
@@ -503,7 +503,10 @@ namespace Aetherium.Items
 
                 //Apply heal based on previous boost applied. We've changed max health, so we need to heal.
                 float difference = BotBody.maxHealth - PreviousRecordedMaxHealth;
-                BotBody.healthComponent.Heal(difference, default(RoR2.ProcChainMask), true);
+                if (difference > 0)
+                {
+                    BotBody.healthComponent.Heal(difference, default(RoR2.ProcChainMask), true);
+                }
                 PreviousRecordedMaxHealth = BotBody.maxHealth;
             }
 


### PR DESCRIPTION
# Project
Define a `DEBUG` constant for the project. Enable this if are in need to debug multiplayer scenarios.

Use `#define DEBUG` to enable.

Use `#undef DEBUG` to disable.

Make sure to disable this when releasing.

# Improvements

### Teleportation Code

Teleportation code is moved to `BotStatTracker` component. There is no need to hook into `CharacterBody.FixedUpdate` because the component itself has a `FixedUpdate` as well that Unity utilizes. Teleportation code was then moved to `BotStatTracker.FixedUpdate` and the related hook was removed.

### BotStatTracker.UpdateTrackerBoosts

All related boost updating is moved into `BotStatTracker` component. This renders the code to be easily reusable. Logic is also clean as it modifies its own fields rather than the `Item` class handling it. Overly accessed elements or variables are cached into the component's instance as well.

### BotStatTracker.ApplyTrackerBoosts

All related boost application is also moved into `BotStatTracker` component. This piece of function will be easily reusable as well as logic is handled by the proper class.

# Fixes

### Healing when max health is boosted

There existed a bug where the drone instead heals the supposed health boost every frame. This is fixed by creating a previous max health variable to track the actual and real difference in between boosts. The real difference is then healed to the drone.

### Overwriting Stocks and Recharge Intervals

The original code before was overwriting the drone's instance values of `maxStock` and `finalRechargeInterval` for their skills. because it was overwritten, the default is lost and recalculated values will be wrong upon changing values of the item's count. This is fixed by initializing the defaults into a separate list, and recalculations will always refer to the default values instead of itself.

# New Feature

### Immediate Effects of Inspiring Drone buffs

Implemented a real-time update on all drones upon receiving **or** losing an Inspiring Drone. Drones will be Inspired if there is one or more of such item. They will go back to their default stats if all Inspiring Drones were lost. Teleportation is also handled properly and stopped if there are no Inspiring Drone items on the player's inventory.

This is disabled by default, but can be enabled through mod configs.