### PR TITLE
Various Improvements and Fixes

### DIFF
--- a/Aetherium/Items/InspiringDrone.cs
+++ b/Aetherium/Items/InspiringDrone.cs
@@ -380,10 +380,10 @@ namespace Aetherium.Items
 
             public string BotName;
             public CharacterMaster BotOwnerMaster;
-            public CharacterBody BotOwnerBody;
             public CharacterMaster BotMaster;
-            public CharacterBody BotBody;
 
+            private CharacterBody _BotOwnerBody;
+            private CharacterBody _BotBody;
             private float TeleportTimer = 0f;
             private int BoostCount = -1;
             private List<int> BotSkillStocks = new List<int>();
@@ -391,9 +391,25 @@ namespace Aetherium.Items
             private List<int> DefaultSkillStocks = new List<int>();
             private List<float> DefaultRechargeIntervals = new List<float>();
             private static string[] BlacklistedStockBots = { "Drone2Master", "EmergencyDroneMaster", "FlameDroneMaster", "EquipmentDroneMaster" };
-            private float PreviousRecordedMaxHealth = -1;
             private string OriginalName = "";
             private InspiringDrone inst = InspiringDrone.instance;
+
+            public CharacterBody BotBody
+            {
+                get
+                {
+                    if (!_BotBody) _BotBody = BotMaster.GetBody();
+                    return _BotBody;
+                }
+            }
+            public CharacterBody BotOwnerBody
+            {
+                get
+                {
+                    if (!_BotOwnerBody) _BotOwnerBody = BotOwnerMaster.GetBody();
+                    return _BotOwnerBody;
+                }
+            }
 
             public static BotStatTracker GetOrAddComponent(CharacterMaster bot, CharacterMaster owner = null)
             {
@@ -402,14 +418,11 @@ namespace Aetherium.Items
                 {
                     tracker = bot.gameObject.AddComponent<BotStatTracker>();
                     tracker.BotMaster = bot;
-                    tracker.BotBody = bot.GetBody();
                     tracker.BotOwnerMaster = owner;
-                    tracker.BotOwnerBody = owner.GetBody();
                 }
                 else if (owner)
                 {
                     tracker.BotOwnerMaster = owner;
-                    tracker.BotOwnerBody = owner.GetBody();
                 }
                 return tracker;
             }

--- a/Aetherium/Items/WeightedAnklet.cs
+++ b/Aetherium/Items/WeightedAnklet.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using TILER2;
 using UnityEngine;
 using static TILER2.MiscUtil;
+using static TILER2.StatHooks;
 
 namespace Aetherium.Items
 {
@@ -179,23 +180,22 @@ namespace Aetherium.Items
                 ItemBodyModelPrefab = regDef.pickupModelPrefab;
                 regItem.ItemDisplayRules = GenerateItemDisplayRules();
             }
-            On.RoR2.CharacterBody.RecalculateStats += MoveSpeedReduction;
+            GetStatCoefficients += MoveSpeedReduction;
             On.RoR2.HealthComponent.TakeDamage += ReduceKnockback;
         }
 
         protected override void UnloadBehavior()
         {
-            On.RoR2.CharacterBody.RecalculateStats -= MoveSpeedReduction;
+            GetStatCoefficients -= MoveSpeedReduction;
             On.RoR2.HealthComponent.TakeDamage -= ReduceKnockback;
         }
 
-        private void MoveSpeedReduction(On.RoR2.CharacterBody.orig_RecalculateStats orig, RoR2.CharacterBody self)
+        private void MoveSpeedReduction(CharacterBody sender, StatHookEventArgs args)
         {
-            orig(self);
-            var InventoryCount = GetCount(self);
+            var InventoryCount = GetCount(sender);
             if (InventoryCount > 0)
             {
-                self.moveSpeed *= Mathf.Clamp(1 - (InventoryCount * baseMovementSpeedReductionPercentage), movementSpeedReductionPercentageCap, 1);
+                args.moveSpeedMultAdd -= Mathf.Min(InventoryCount * baseMovementSpeedReductionPercentage, movementSpeedReductionPercentageCap);
             }
         }
 


### PR DESCRIPTION
# Improvements
Utilize TILER2 for hooking in `RecalculateStats` using its IL and event. Inspiring Drone now uses this and it works perfectly.

# Fixes
Allow `CharacterBody` components For `BotStatTracker` to be referenced and cached instead of directly storing it. This should lessen checks for as long as the `CharacterMaster` is stored.

Weighted Anklet is now updated to use TILER2's hooking. Multiplier is passed to IL and is now compatible with other mods.