### PR TITLE
TIler2Compat Implementation Sample

### DIFF
--- a/Aetherium/Compatability/ModCompatability.cs
+++ b/Aetherium/Compatability/ModCompatability.cs
@@ -3,9 +3,8 @@ using RoR2;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using static Aetherium.Utils.MathHelpers;
-using System.Text;
 using UnityEngine;
+using static Aetherium.Utils.MathHelpers;
 
 namespace Aetherium.Compatability
 {
@@ -26,7 +25,6 @@ namespace Aetherium.Compatability
             {
                 ItemStats.ItemStatDef SipCooldownStatDef = new ItemStats.ItemStatDef
                 {
-
                     Stats = new List<ItemStats.Stat.ItemStat>()
                 {
                     new ItemStats.Stat.ItemStat
@@ -411,6 +409,39 @@ namespace Aetherium.Compatability
                 }
                 };
                 ItemStats.ItemStatsMod.AddCustomItemStatDef(WitchesRing.instance.ItemDef.itemIndex, WitchesRingStatDefs);
+            }
+        }
+
+        internal static class Tiler2Compat
+        {
+            [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+            public static void Tiler2GetStatsCoefficient(Action<CharacterBody, TILER2.StatHooks.StatHookEventArgs> action)
+            {
+                TILER2.StatHooks.GetStatCoefficients += (sender, args) =>
+                {
+                    action(sender, args);
+                };
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+            public static void Tiler2ShieldingCoreSupport()
+            {
+                Tiler2GetStatsCoefficient((sender, args) =>
+                {
+                    if (ShieldingCore.instance.GetCount(sender) > 0)
+                    {
+                        RoR2.HealthComponent healthC = sender.GetComponent<RoR2.HealthComponent>();
+                        args.baseShieldAdd += healthC.fullHealth * ShieldingCore.BaseGrantShieldMultiplier;
+                    }
+                });
+                Tiler2GetStatsCoefficient((sender, args) =>
+                {
+                    var ShieldedCoreComponent = sender.GetComponent<ShieldingCore.ShieldedCoreComponent>();
+                    if (ShieldedCoreComponent && ShieldedCoreComponent.cachedIsShielded && ShieldedCoreComponent.cachedInventoryCount > 0)
+                    {
+                        args.armorAdd += ShieldingCore.BaseShieldingCoreArmorGrant + (ShieldingCore.AdditionalShieldingCoreArmorGrant * (ShieldedCoreComponent.cachedInventoryCount - 1));
+                    }
+                });
             }
         }
     }

--- a/Aetherium/CoreModules/Stathooks.cs
+++ b/Aetherium/CoreModules/Stathooks.cs
@@ -16,9 +16,13 @@ namespace Aetherium.CoreModules
     public class StatHooks : CoreModule
     {
         public override string Name => "StatHooks (from TILER2 originally)";
+
         public override void Init()
         {
-            IL.RoR2.CharacterBody.RecalculateStats += IL_CBRecalcStats;
+            if (!AetheriumPlugin.IsTiler2Installed)
+            {
+                IL.RoR2.CharacterBody.RecalculateStats += IL_CBRecalcStats;
+            }
         }
 
         /// <summary>

--- a/Aetherium/Items/ShieldingCore.cs
+++ b/Aetherium/Items/ShieldingCore.cs
@@ -2,21 +2,14 @@
 using BepInEx.Configuration;
 using On.RoR2;
 using R2API;
-using R2API.Utils;
 using RoR2;
-using System;
 using UnityEngine;
-using ItemStats;
-using ItemStats.Stat;
-using ItemStats.ValueFormatters;
-
 using static Aetherium.AetheriumPlugin;
+using static Aetherium.Compatability.ModCompatability.ItemStatsModCompat;
+using static Aetherium.Compatability.ModCompatability.Tiler2Compat;
 using static Aetherium.CoreModules.StatHooks;
 using static Aetherium.Utils.ItemHelpers;
 using static Aetherium.Utils.MathHelpers;
-using static Aetherium.Compatability.ModCompatability.ItemStatsModCompat;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Aetherium.Items
 {
@@ -240,9 +233,16 @@ namespace Aetherium.Items
                 RoR2.RoR2Application.onLoad += ItemStatsModCompat;
             }
 
-            GetStatCoefficients += GrantBaseShield;
             On.RoR2.CharacterBody.FixedUpdate += ShieldedCoreValidator;
-            GetStatCoefficients += ShieldedCoreArmorCalc;
+            if (IsTiler2Installed)
+            {
+                Tiler2ShieldingCoreSupport();
+            }
+            else
+            {
+                GetStatCoefficients += GrantBaseShield;
+                GetStatCoefficients += ShieldedCoreArmorCalc;
+            }
         }
 
         private void ItemStatsModCompat()
@@ -331,9 +331,9 @@ namespace Aetherium.Items
             public ParticleSystem[] ParticleSystem;
             public RoR2.CharacterMaster OwnerMaster;
             public RoR2.CharacterBody OwnerBody;
+
             public void FixedUpdate()
             {
-
                 if (!OwnerMaster || !ItemDisplay || ParticleSystem.Length != 3)
                 {
                     ItemDisplay = this.GetComponentInParent<RoR2.ItemDisplay>();
@@ -365,7 +365,7 @@ namespace Aetherium.Items
                     {
                         if (ParticleSystem.Length == 3)
                         {
-                            for(int i = 0; i < ParticleSystem.Length; i++)
+                            for (int i = 0; i < ParticleSystem.Length; i++)
                             {
                                 UnityEngine.Object.Destroy(ParticleSystem[i]);
                             }


### PR DESCRIPTION
**Do not merge.**

Please review the implementation of the following. This is so that TILER2 mods will work with Aetherium. Only Shielding Core has the following sample implementation of the Compat.

**This is untested, but it compiled.**

Related issue: #42 