### PR TITLE
Engineer's Toolbelt API for Custom Drones

### DIFF
--- a/Aetherium/Items/EngineersToolbelt.cs
+++ b/Aetherium/Items/EngineersToolbelt.cs
@@ -46,15 +46,15 @@ namespace Aetherium.Items
             ItemName,
 
             "9/9/2079",
-            
+
             "UES Safe Travels/Unmarked Sector/Outer Rim",
 
             "667********",
-            
+
             ItemPickupDesc,
-            
+
             "Next Day Delivery / Common Industrial / Small",
-            
+
             "Hey Pal,\n" +
             "\nJust got your delivery request for a replacement toolbelt. Couldn't believe that the Safe Travels doesn't have a single one of them on board. " +
             "We've been running low on some supplies here so all this stuff is what I had on hand. Included in the belt there's everything your standard Drone and Turret repair technician would need." +
@@ -108,7 +108,6 @@ namespace Aetherium.Items
 
             BaseRevivalPercentChance = config.ActiveBind<float>("Item: " + ItemName, "Base Revival Percentage Chance", 0.1f, "What chance in percentage should a drone or turret have of reviving on death with the first stack of this?");
             AdditionalRevivalPercentChance = config.ActiveBind<float>("Item: " + ItemName, "Additional Revival Percentage Chance", 0.1f, "What chance in percentage should a drone or turret have of reviving on death per additional stack?");
-
         }
 
         public override ItemDisplayRuleDict CreateItemDisplayRules()
@@ -291,12 +290,12 @@ namespace Aetherium.Items
 
                             if (characterBody && characterBody.master && inventoryCount > 0)
                             {
-                                if (Util.CheckRoll(InverseHyperbolicScaling(BaseDuplicationPercentChance, AdditionalDuplicationPercentChance, 1, inventoryCount)*100, characterBody.master))
+                                if (Util.CheckRoll(InverseHyperbolicScaling(BaseDuplicationPercentChance, AdditionalDuplicationPercentChance, 1, inventoryCount) * 100, characterBody.master))
                                 {
                                     Vector3 chosenPosition = Vector3.zero;
 
                                     var masterPrefabMaster = masterPrefab.GetComponent<CharacterMaster>();
-                                    if(masterPrefabMaster && masterPrefabMaster.bodyPrefab)
+                                    if (masterPrefabMaster && masterPrefabMaster.bodyPrefab)
                                     {
                                         var duplicationBody = masterPrefabMaster.bodyPrefab.GetComponent<CharacterBody>();
                                         if (duplicationBody)
@@ -312,7 +311,6 @@ namespace Aetherium.Items
                                         rotation = self.transform.rotation,
                                         summonerBodyObject = activator.gameObject,
                                         ignoreTeamMemberLimit = true,
-
                                     }.Perform();
 
                                     if (droneName == "EquipmentDroneMaster")
@@ -351,8 +349,8 @@ namespace Aetherium.Items
                             foreach (string droneName in DronesList)
                             {
                                 if (characterBody.name.Contains(droneName))
-                                {                                    
-                                    var shouldWeRevive = Util.CheckRoll(InverseHyperbolicScaling(BaseRevivalPercentChance, AdditionalRevivalPercentChance, 1, inventoryCount)*100, self.master.minionOwnership.ownerMaster);
+                                {
+                                    var shouldWeRevive = Util.CheckRoll(InverseHyperbolicScaling(BaseRevivalPercentChance, AdditionalRevivalPercentChance, 1, inventoryCount) * 100, self.master.minionOwnership.ownerMaster);
                                     if (shouldWeRevive)
                                     {
                                         var originalOwner = self.master.minionOwnership.ownerMaster;
@@ -377,6 +375,18 @@ namespace Aetherium.Items
             orig(self, characterBody);
         }
 
+        /// <summary>
+        /// Allows a custom drone to be revived by Engineer's Toolbelt.
+        /// </summary>
+        /// <param name="bodyName">The CharacterBody name of the custom drone.</param>
+        /// <returns>True if the custom drone is now supported. False if the custom drone is already supported.</returns>
+        public bool AddCustomDrone(string bodyName)
+        {
+            if (DronesList.Exists(item => item == bodyName)) return false;
+            DronesList.Add(bodyName);
+            return true;
+        }
+
         public class EngineersToolbeltRevivalComponent : MonoBehaviour
         {
             public CharacterMaster Owner;
@@ -384,11 +394,11 @@ namespace Aetherium.Items
 
             public void FixedUpdate()
             {
-                if(Master && Master.hasBody && Master.GetBody().healthComponent.alive)
+                if (Master && Master.hasBody && Master.GetBody().healthComponent.alive)
                 {
                     Master.destroyOnBodyDeath = true;
 
-                    foreach(BaseAI ai in Master.aiComponents)
+                    foreach (BaseAI ai in Master.aiComponents)
                     {
                         ai.leader.gameObject = Owner.gameObject;
                     }

--- a/Aetherium/Items/EngineersToolbelt.cs
+++ b/Aetherium/Items/EngineersToolbelt.cs
@@ -2,7 +2,6 @@
 using BepInEx.Configuration;
 using R2API;
 using RoR2;
-using RoR2.CharacterAI;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -22,7 +21,7 @@ namespace Aetherium.Items
         public static ConfigOption<float> BaseRevivalPercentChance;
         public static ConfigOption<float> AdditionalRevivalPercentChance;
 
-        public override string ItemName => "Engineer's Toolbelt";
+        public override string ItemName => "Engineers Toolbelt";
 
         public override string ItemLangTokenName => "ENGINEERS_TOOLBELT";
 
@@ -279,6 +278,10 @@ namespace Aetherium.Items
                                 //engineerRevivalComponent.Master = self.master;
 
                                 master.inventory.GiveItem(RoR2Content.Items.ExtraLife);
+                                if (!characterBody.GetComponent<EngineersToolbeltRevivalFlag>())
+                                {
+                                    characterBody.gameObject.AddComponent<EngineersToolbeltRevivalFlag>();
+                                }
                             }
                         }
                     }
@@ -432,5 +435,24 @@ namespace Aetherium.Items
         //        }
         //    }
         //}
+
+        /// <summary>
+        /// A component flag for checking if the drone is revived by means of the effect of Engineer's Toolbelt.
+        /// </summary>
+        public class EngineersToolbeltRevivalFlag : MonoBehaviour
+        {
+            public CharacterMaster ownerMaster;
+            public CharacterMaster droneMaster;
+            public CharacterBody droneBody;
+            public CharacterBody ownerBody;
+
+            private void Awake()
+            {
+                droneBody = gameObject.GetComponent<CharacterBody>();
+                droneMaster = droneBody.master;
+                ownerMaster = droneMaster.minionOwnership.ownerMaster;
+                ownerBody = ownerMaster.GetBody();
+            }
+        }
     }
 }


### PR DESCRIPTION
Implement an API so that custom drones can be also revived by the item.

### New Features
#### Custom Drones Support
Custom Drones can now be fully supported through the API. Just Add the CharacterMaster name and it will be registered in the DronesList data structure.

### Improvements
#### Duplication Implementation
The duplication implementation now catches all null reference exceptions that may occur. It now also supports drone checking based on DronesList. The prefab fetching is also improved by getting the the SummonMasterBehavior component and fetch the master prefab from there instead of string manipulation.
#### Revival Implementation
It is also improved by catching all null reference exceptions. It also now supports drones based on DronesList. The hooking is changed from BaseAI to CharacterMaster as this was more appropriate, where as the CharacterMaster still exists in this context when needed, hence keeping ownership information automatically towards the revived drone.
#### Revival Flagging through Engineers Toolbelt
Revived drones through this item's effect will be flagged by a component, useful for those mods with behavioral changes to how the drones work. Compatibility implementations will be possible through this.

### Existing Issues not worked on
Before improvements were coded in, there was already an issue with the item. The drones duped are not being positioned to correct nodes. I assume that the check does not include "taken" nodes and thus finds the nearest node that was taken (which is the original drone's position). This was not worked on yet, but I have a solution in mind. Use Inspiring Drone's teleport logic (without the effects) to quickly reposition and find the available node that is not taken.