### PR TITLE
Enforcer Item displays, Blaster sword and a few others

### DIFF
--- a/Aetherium/Equipment/BellTotem.cs
+++ b/Aetherium/Equipment/BellTotem.cs
@@ -420,9 +420,18 @@ namespace Aetherium.Equipment
                     ruleType = ItemDisplayRuleType.ParentedPrefab,
                     followerPrefab = ItemBodyModelPrefab,
                     childName = "HammerHeadFront",
-                    localPos = new Vector3(0.00007F, -0.20318F, -0.00036F),
+                    localPos =    new Vector3(0.00408F, -0.26034F, -0.08745F),
                     localAngles = new Vector3(358.5298F, 5.5261F, 359.8578F),
-                    localScale = new Vector3(0.08471F, 0.08471F, 0.08471F)
+                    localScale =  new Vector3(0.15374F, 0.15374F, 0.15374F)
+                },
+                new RoR2.ItemDisplayRule
+                {
+                    ruleType = ItemDisplayRuleType.ParentedPrefab,
+                    followerPrefab = ItemBodyModelPrefab,
+                    childName = "NeedlerItems",
+                    localPos =    new Vector3(-0.35184F, 0.42466F, 0.06943F),
+                    localAngles = new Vector3(0F, 257.0276F, 0F),
+                    localScale =  new Vector3(0.08976F, 0.08976F, 0.08976F)
                 },
             });
             rules.Add("NemesisEnforcerBody", new RoR2.ItemDisplayRule[]

--- a/Aetherium/Items/AccursedPotion.cs
+++ b/Aetherium/Items/AccursedPotion.cs
@@ -301,9 +301,9 @@ namespace Aetherium.Items
                     ruleType = ItemDisplayRuleType.ParentedPrefab,
                     followerPrefab = ItemBodyModelPrefab,
                     childName = "ThighR",
-                    localPos = new Vector3(-0.07489F, -0.00166F, 0.17528F),
+                    localPos =    new Vector3(-0.0809F, 0.0543F, 0.19989F),
                     localAngles = new Vector3(356.8972F, 183.9839F, 175.9352F),
-                    localScale = new Vector3(0.04209F, 0.04209F, 0.04209F)
+                    localScale =  new Vector3(0.07479F, 0.07479F, 0.07479F)
                 }
             });
             rules.Add("NemesisEnforcerBody", new RoR2.ItemDisplayRule[]

--- a/Aetherium/Items/BlasterSword.cs
+++ b/Aetherium/Items/BlasterSword.cs
@@ -528,11 +528,56 @@ namespace Aetherium.Items
                 {
                     ruleType = ItemDisplayRuleType.ParentedPrefab,
                     followerPrefab = ItemBodyModelPrefab,
-                    childName = "Model",
-                    localPos = new Vector3(0, 0, 0),
-                    localAngles = new Vector3(0, 0, 0),
-                    localScale = new Vector3(1, 1, 1)
-                }
+                    childName =  "ShotgunItems",
+                    localPos =   new Vector3(1.14057F, -0.01415F, 0.05927F),
+                    localAngles =new Vector3(0F, 0F, 90F),
+                    localScale = new Vector3(0.07379F, 0.07379F, 0.07379F)
+                },
+                new RoR2.ItemDisplayRule
+                {
+                    ruleType = ItemDisplayRuleType.ParentedPrefab,
+                    followerPrefab = ItemBodyModelPrefab,
+                    childName =  "SSGBarrelItems",
+                    localPos =   new Vector3(-0.00527F, 1.13731F, 0.0219F),
+                    localAngles =new Vector3(0F, 90F, 180F),
+                    localScale = new Vector3(0.07379F, 0.07379F, 0.07379F)
+                },
+                new RoR2.ItemDisplayRule
+                {
+                    ruleType = ItemDisplayRuleType.ParentedPrefab,
+                    followerPrefab = ItemBodyModelPrefab,
+                    childName =  "HMGItems",
+                    localPos =   new Vector3(1.07765F, -0.01496F, 0.05527F), 
+                    localAngles =new Vector3(0F, 0F, 90F),
+                    localScale = new Vector3(0.06306F, 0.07538F, 0.06306F)
+                },
+                new RoR2.ItemDisplayRule
+                {
+                    ruleType = ItemDisplayRuleType.ParentedPrefab,
+                    followerPrefab = ItemBodyModelPrefab,
+                    childName =  "HammerHeadFront",
+                    localPos =   new Vector3(0.00013F, 0.01796F, -0.38599F), 
+                    localAngles =new Vector3(0F, 90F, 90F),
+                    localScale = new Vector3(0.14598F, 0.13813F, 0.14598F)
+                },
+                new RoR2.ItemDisplayRule
+                {
+                    ruleType = ItemDisplayRuleType.ParentedPrefab,
+                    followerPrefab = ItemBodyModelPrefab,
+                    childName =  "NeedlerItems",
+                    localPos =   new Vector3(0.47427F, -0.17845F, -0.01515F), 
+                    localAngles =new Vector3(0F, 0F, 91.16087F),
+                    localScale = new Vector3(0.14598F, 0.13813F, 0.14598F)
+                },
+                new RoR2.ItemDisplayRule
+                {
+                    ruleType = ItemDisplayRuleType.ParentedPrefab,
+                    followerPrefab = ItemBodyModelPrefab,
+                    childName =  "NeedlerItems",
+                    localPos =   new Vector3(0.48428F, 0.2955F, -0.01517F), 
+                    localAngles =new Vector3(0F, 0F, 88.8F),
+                    localScale = new Vector3(0.14598F, 0.13813F, 0.14598F)
+                },
             });
             rulesNormal.Add("NemesisEnforcerBody", new RoR2.ItemDisplayRule[]
             {

--- a/Aetherium/Items/EngineersToolbelt.cs
+++ b/Aetherium/Items/EngineersToolbelt.cs
@@ -310,10 +310,10 @@ namespace Aetherium.Items
                 {
                     ruleType = ItemDisplayRuleType.ParentedPrefab,
                     followerPrefab = ItemBodyModelPrefab,
-                    childName = "Pelvis",
-                    localPos = new Vector3(0F, 0.09452F, 0F),
-                    localAngles = new Vector3(0F, 347.7791F, 180F),
-                    localScale = new Vector3(0.39468F, 0.39468F, 0.39468F)
+                    childName =  "Pelvis",
+                    localPos =   new Vector3(0.00784F, 0.05264F, 0.00931F), 
+                    localAngles = new Vector3(8.1354F, 273.3271F, 181.3306F),
+                    localScale = new Vector3(0.3227F, 0.31414F, 0.29262F)
                 }
             });
             rules.Add("NemesisEnforcerBody", new RoR2.ItemDisplayRule[]

--- a/Aetherium/Items/WitchesRing.cs
+++ b/Aetherium/Items/WitchesRing.cs
@@ -465,6 +465,15 @@ namespace Aetherium.Items
                 new RoR2.ItemDisplayRule
                 {
                     ruleType = ItemDisplayRuleType.ParentedPrefab,
+                    followerPrefab = ItemBodyModelPrefab,
+                    childName =   "NeedlerItems",
+                    localPos =    new Vector3(-0.15368F, 0.11949F, -0.01714F),
+                    localAngles = new Vector3(343.9558F, 0F, 90F),
+                    localScale =  new Vector3(0.23553F, 0.24472F, 0.23553F)
+                },
+                new RoR2.ItemDisplayRule
+                {
+                    ruleType = ItemDisplayRuleType.ParentedPrefab,
                     followerPrefab = CircleBodyModelPrefab,
                     childName = "ShotgunItems",
                     localPos = new Vector3(1.00937F, -0.04993F, 0.00758F),
@@ -478,7 +487,7 @@ namespace Aetherium.Items
                     childName = "SSGBarrelItems",
                     localPos = new Vector3(-0.03745F, 1.07244F, 0.07575F),
                     localAngles = new Vector3(90F, 0F, 0F),
-                    localScale = new Vector3(0.034F, 0.034F, 0F)
+                    localScale = new Vector3(0.08F, 0.08F, 0F)
                 },
                 new RoR2.ItemDisplayRule
                 {
@@ -487,7 +496,7 @@ namespace Aetherium.Items
                     childName = "SSGBarrelItems",
                     localPos = new Vector3(0.03198F, 1.0725F, 0.07575F),
                     localAngles = new Vector3(90F, 0F, 0F),
-                    localScale = new Vector3(0.034F, 0.034F, 0F)
+                    localScale = new Vector3(0.08F, 0.08F, 0F)
                 },
                 new RoR2.ItemDisplayRule
                 {
@@ -506,6 +515,15 @@ namespace Aetherium.Items
                     localPos = new Vector3(0.00004F, 1.51978F, -0.00007F),
                     localAngles = new Vector3(90F, 0F, 0F),
                     localScale = new Vector3(0.33855F, 0.33855F, 0.00003F)
+                },
+                new RoR2.ItemDisplayRule
+                {
+                    ruleType = ItemDisplayRuleType.ParentedPrefab,
+                    followerPrefab = CircleBodyModelPrefab,
+                    childName =   "NeedlerItems",
+                    localPos =    new Vector3(0.22771F, 0.07286F, -0.00003F),
+                    localAngles = new Vector3(0F, 90F, 0F),
+                    localScale =  new Vector3(0.26724F, 0.26724F, 0.00002F)
                 },
             });
             rules.Add("NemesisEnforcerBody", new RoR2.ItemDisplayRule[]


### PR DESCRIPTION
 - Added Blaster Sword displays on all weapons.
 - Shrunk engineer's toolbelt a bit. Was a bit crazy big especially on other skins
 - Grew up Accursed potion a bit. et so teeny
 - Grew up Bell Totem on hammer display a bit, it teeny. 
   - Equipments since they're not permanent can stand to have little bigger displays usually.
   - also added needler  
 - Grew up the ring circles on the barrels of SSG, so they're at least visible from behind.
   - Added needler